### PR TITLE
Web DeviceMotionEvent for PlayerMovement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,26 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "MonsterJump",
+      "name": "Debug",
       "request": "launch",
-      "type": "dart"
+      "type": "dart",
+      "program": "lib/main.dart",
+      "flutterMode": "debug"
+    },
+    {
+      "name": "Profile",
+      "type": "dart",
+      "request": "launch",
+      "program": "lib/main.dart",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "Release",
+      "type": "dart",
+      "request": "launch",
+      "program": "lib/main.dart",
+      "flutterMode": "release"
+    },
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
       "program": "lib/main.dart",
       "deviceId": "web-server",
       "flutterMode": "release",
-      "args": ["--web-hostname", "127.0.0.1", "--web-port 8989"],
+      "args": ["--web-hostname", "127.0.0.1", "--web-port", "8989"],
       "internalConsoleOptions": "openOnSessionStart"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
       "program": "lib/main.dart",
       "deviceId": "web-server",
       "flutterMode": "release",
-      "args": ["--web-hostname 127.0.0.1"],
+      "args": ["--web-hostname", "127.0.0.1", "--web-port 8989"],
       "internalConsoleOptions": "openOnSessionStart"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,15 @@
       "program": "lib/main.dart",
       "flutterMode": "release"
     },
+    {
+      "name": "Web Server Local Release",
+      "type": "dart",
+      "request": "launch",
+      "program": "lib/main.dart",
+      "deviceId": "web-server",
+      "flutterMode": "release",
+      "args": ["--web-hostname 127.0.0.1"],
+      "internalConsoleOptions": "openOnSessionStart"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
       "program": "lib/main.dart",
       "deviceId": "web-server",
       "flutterMode": "release",
-      "args": ["--web-hostname", "127.0.0.1", "--web-port", "8989"],
+      "args": ["--web-hostname", "0.0.0.0", "--web-port", "8989"],
       "internalConsoleOptions": "openOnSessionStart"
     }
   ]

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,6 +1,3 @@
-@JS()
-library t; // TODO move JS stuff to web only?
-
 import 'dart:async';
 import 'dart:html'; // TODO move to web only?
 import 'dart:math';
@@ -16,7 +13,8 @@ import 'package:js/js.dart';
 import 'package:monsterjump/utils/globals.dart';
 import 'package:sensors/sensors.dart';
 
-@JS()
+// ignore: missing_js_lib_annotation
+@JS("requestDeviceMotionEventPermission")
 external void requestDeviceMotionEventPermission();
 
 const double SIZE = 48.0;

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -44,6 +44,9 @@ class Player extends SpriteComponent {
       gyroListenerWeb = (event) {
         print("devicemotion – event: $event");
       };
+      if (DeviceMotionEvent != null &&
+          DeviceMotionEvent.requestPermission != null)
+        DeviceMotionEvent.requestPermission();
       document.window.addEventListener('devicemotion', gyroListenerWeb);
     }
   }

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:html'; // TODO move to web only?
 import 'dart:math';
 import 'dart:ui';
 import 'package:flame/components/component.dart';
@@ -19,7 +20,10 @@ class Player extends SpriteComponent {
   PlayerBody body;
   bool willDestroy = false;
   Vector2 acceleration = Vector2.zero();
-  StreamSubscription gyroSub;
+
+  StreamSubscription gyroSubNative;
+  Gyroscope gyroSensorWeb;
+  EventListener gyroListenerWeb;
 
   Player(Box2DComponent box, {double x: 0, double y: -160})
       : super.fromSprite(SIZE, SIZE, new Sprite("monster/monster.png")) {
@@ -31,19 +35,28 @@ class Player extends SpriteComponent {
 
   void start() {
     if (!kIsWeb) {
-      // mobile
-      gyroSub = gyroscopeEvents.listen((GyroscopeEvent event) {
+      // nativemobile
+      gyroSubNative = gyroscopeEvents.listen((GyroscopeEvent event) {
         //Adding up the scaled sensor data to the current acceleration
         acceleration = Vector2(event.y * sensorScale, 0);
       });
     } else {
       // web
-
+      print("hello web :) ;");
+      gyroListenerWeb = (event) => print("gyroListenerWeb – event: $event");
+      gyroSensorWeb = new Gyroscope();
+      gyroSensorWeb.addEventListener('reading', gyroListenerWeb);
+      gyroSensorWeb.start();
     }
   }
 
   void stop() {
-    if (gyroSub != null) gyroSub.cancel();
+    if (!kIsWeb) {
+      // native mobile
+      if (gyroSubNative != null) gyroSubNative.cancel();
+    } else {
+      // web
+    }
   }
 
   @override

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -13,7 +13,7 @@ import 'package:sensors/sensors.dart';
 
 const double SIZE = 48.0;
 const double sensorScale = 3;
-const double horResistance = 0; //TODO does this improve gameplay?
+const double horResistance = 0;
 
 class Player extends SpriteComponent {
   PlayerBody body;

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -121,7 +121,7 @@ class PlayerBody extends BodyComponent {
 
   void _createBody() {
     final shape = new CircleShape();
-    shape.radius = 0.3 * SIZE * Globals.ptm;
+    shape.radius = 0.3 * Player.size * Globals.ptm;
 
     final fixtureDef = new FixtureDef();
     fixtureDef.shape = shape;

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -30,11 +30,16 @@ class Player extends SpriteComponent {
   }
 
   void start() {
-    if (!kIsWeb)
+    if (!kIsWeb) {
+      // mobile
       gyroSub = gyroscopeEvents.listen((GyroscopeEvent event) {
         //Adding up the scaled sensor data to the current acceleration
         acceleration = Vector2(event.y * sensorScale, 0);
       });
+    } else {
+      // web
+
+    }
   }
 
   void stop() {

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,3 +1,6 @@
+@JS()
+library t; // TODO move JS stuff to web only?
+
 import 'dart:async';
 import 'dart:html'; // TODO move to web only?
 import 'dart:math';
@@ -9,8 +12,12 @@ import 'package:flame/box2d/box2d_component.dart';
 import 'package:box2d_flame/box2d.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:js/js.dart';
 import 'package:monsterjump/utils/globals.dart';
 import 'package:sensors/sensors.dart';
+
+@JS()
+external void requestDeviceMotionEventPermission();
 
 const double SIZE = 48.0;
 const double sensorScale = 3;
@@ -44,9 +51,10 @@ class Player extends SpriteComponent {
       gyroListenerWeb = (event) {
         print("devicemotion – event: $event");
       };
-      if (DeviceMotionEvent != null &&
-          DeviceMotionEvent.requestPermission != null)
-        DeviceMotionEvent.requestPermission();
+
+      // TODO move logic to dart once DeviceMotionEvent.requestPermission() is supported: https://github.com/dart-lang/sdk/issues/41337
+      requestDeviceMotionEventPermission();
+
       document.window.addEventListener('devicemotion', gyroListenerWeb);
     }
   }

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -22,7 +22,6 @@ class Player extends SpriteComponent {
   Vector2 acceleration = Vector2.zero();
 
   StreamSubscription gyroSubNative;
-  Gyroscope gyroSensorWeb;
   EventListener gyroListenerWeb;
 
   Player(Box2DComponent box, {double x: 0, double y: -160})
@@ -42,11 +41,10 @@ class Player extends SpriteComponent {
       });
     } else {
       // web
-      print("hello web :) ;");
-      gyroListenerWeb = (event) => print("gyroListenerWeb – event: $event");
-      gyroSensorWeb = new Gyroscope();
-      gyroSensorWeb.addEventListener('reading', gyroListenerWeb);
-      gyroSensorWeb.start();
+      gyroListenerWeb = (event) {
+        print("devicemotion – event: $event");
+      };
+      document.window.addEventListener('devicemotion', gyroListenerWeb);
     }
   }
 
@@ -56,6 +54,7 @@ class Player extends SpriteComponent {
       if (gyroSubNative != null) gyroSubNative.cancel();
     } else {
       // web
+      document.window.removeEventListener('devicemotion', gyroListenerWeb);
     }
   }
 

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/foundation.dart';
 import 'package:monsterjump/components/level_wrapper.dart';
 import 'package:monsterjump/utils/admob.dart';
 import 'package:monsterjump/utils/score.dart';
@@ -76,7 +77,7 @@ class CoronaJump extends BaseGame with HasWidgetsOverlay {
       player.start();
 
       // To keep the screen on:
-      Wakelock.enable();
+      if (!kIsWeb) Wakelock.enable();
     }
   }
 
@@ -101,7 +102,7 @@ class CoronaJump extends BaseGame with HasWidgetsOverlay {
       level.remove();
 
       // To let the screen turn off again:
-      Wakelock.disable();
+      if (!kIsWeb) Wakelock.disable();
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,10 +11,7 @@ void main() {
   //Crashlytics.instance.enableInDevMode = true;
 
   // on uncaught flutter error
-  FlutterError.onError = (details) {
-    print("FlutterERROR: $details");
-    return Crashlytics.instance.recordFlutterError(details);
-  };
+  FlutterError.onError = Crashlytics.instance.recordFlutterError;
 
   // run in zone for stacktrace
   runZoned<Future<void>>(() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:monsterjump/utils/admob.dart';
 import 'package:flutter/material.dart';
@@ -7,30 +8,38 @@ import 'package:flame/util.dart';
 import 'package:monsterjump/game.dart';
 
 void main() {
-  WidgetsFlutterBinding.ensureInitialized();
+  //Crashlytics.instance.enableInDevMode = true;
 
-  // Pass all uncaught errors from the framework to Crashlytics.
-  FlutterError.onError = Crashlytics.instance.recordFlutterError;
+  // on uncaught flutter error
+  FlutterError.onError = (details) {
+    print("FlutterERROR: $details");
+    return Crashlytics.instance.recordFlutterError(details);
+  };
 
-  // Admob setup
-  Admob.init();
-  Admob.loadBannerAd();
+  // run in zone for stacktrace
+  runZoned<Future<void>>(() async {
+    WidgetsFlutterBinding.ensureInitialized();
 
-  // preload images
-  Flame.images.loadAll(<String>[
-    'bg/background.png',
-    'monster/monster.png',
-    'platform/platform.png'
-  ]);
+    // Admob setup
+    Admob.init();
+    Admob.loadBannerAd();
 
-  // Flame settings
-  Util flameUtil = Util();
-  flameUtil.fullScreen();
-  flameUtil.setOrientations(
-      [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+    // preload images
+    Flame.images.loadAll(<String>[
+      'bg/background.png',
+      'monster/monster.png',
+      'platform/platform.png'
+    ]);
 
-  // run app
-  runApp(new GameContainer());
+    // Flame settings
+    Util flameUtil = Util();
+    flameUtil.fullScreen();
+    flameUtil.setOrientations(
+        [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+
+    // run app
+    runApp(GameContainer());
+  }, onError: Crashlytics.instance.recordError);
 }
 
 class GameContainer extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "2.1.4"
   js:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: js
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   cloud_firestore:
 
   # web
-  js: any
+  js: ^0.6.0
 
 dev_dependencies:
   flutter_launcher_icons: ^0.7.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,9 @@ dependencies:
   firebase_admob: ^0.9.0+7
   cloud_firestore:
 
+  # web
+  js: any
+
 dev_dependencies:
   flutter_launcher_icons: ^0.7.4
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -21,7 +21,7 @@
        https://developers.google.com/web/fundamentals/primers/service-workers -->
     <script>
       if ("serviceWorker" in navigator) {
-        window.addEventListener("load", function() {
+        window.addEventListener("load", function () {
           navigator.serviceWorker.register("/flutter_service_worker.js");
         });
       }
@@ -40,7 +40,7 @@
         storageBucket: "coronajump-22640.appspot.com",
         messagingSenderId: "964026911169",
         appId: "1:964026911169:web:4a5adf29aea7554a1d0740",
-        measurementId: "G-662VXG7B0H"
+        measurementId: "G-662VXG7B0H",
       };
       // Initialize Firebase
       firebase.initializeApp(firebaseConfig);
@@ -48,6 +48,7 @@
     </script>
     <!-- END OF FIREBASE INIT CODE -->
 
+    <!-- Let's flutter -->
     <script src="main.dart.js" type="application/javascript"></script>
   </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -48,6 +48,9 @@
     </script>
     <!-- END OF FIREBASE INIT CODE -->
 
+    <!-- JS functions to be called from dart -->
+    <script src="main.js" type="application/javascript"></script>
+
     <!-- Let's flutter -->
     <script src="main.dart.js" type="application/javascript"></script>
   </body>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,27 @@
+function requestDeviceMotionEventPermission() {
+  console.log("requestDeviceMotionEventPermission - called.");
+
+  if (typeof DeviceMotionEvent !== "undefined") {
+    // feature detect
+    if (typeof DeviceMotionEvent.requestPermission === "function") {
+      return DeviceMotionEvent.requestPermission()
+        .then((permissionState) => {
+          console.log(
+            "requestDeviceMotionEventPermission – permissionState: ",
+            permissionState
+          );
+          return permissionState;
+        })
+        .catch((err) =>
+          console.warn("requestDeviceMotionEventPermission – Error: ", err)
+        );
+    } else {
+      // handle regular non iOS 13+ devices
+      console.warn(
+        "requestDeviceMotionEventPermission – DeviceMotionEvent.requestPermission is not defined."
+      );
+    }
+  } else {
+    alert("You're device does not support motion :(");
+  }
+}


### PR DESCRIPTION
See Slqack thread here: https://placesappworkspace.slack.com/archives/G0105CVFU79/p1585771138017300

https://whatwebcando.today/device-motion.html
Tested on iPhone X iOS 13.3.1. 

Turns out from iOS 13, DeviceMotionEvent permission can be requested: https://stackoverflow.com/questions/56514116/how-do-i-get-deviceorientationevent-and-devicemotionevent-to-work-on-safari
For iOS 12 (and earlier?) this setting must be made manual and is disabled by default, according to https://www.macrumors.com/2019/02/04/ios-12-2-safari-motion-orientation-access-toggle/

@adrianpfeiffer, for details on how to tune player horizontal movement, see: https://github.com/abegehr/monsterjump/commit/86cddc194849c0904b417b4660e43664a8985b40